### PR TITLE
Use Pry from console instead of IRB in development

### DIFF
--- a/lib/napa/generators/templates/scaffold/console
+++ b/lib/napa/generators/templates/scaffold/console
@@ -1,5 +1,9 @@
-require 'bundler'
 require './app'
-require 'irb'
-require 'irb/completion'
-IRB.start
+
+begin
+  require 'pry'
+  Pry.start
+rescue LoadError
+  require 'irb/completion'
+  IRB.start
+end


### PR DESCRIPTION
Since `pry` gets bundled by default, we should attempt to load it in the provided
`console` file. If the user has removed Pry or is for some reason in the production
environment, we can fall back to IRB.

Signed-off-by: David Celis me@davidcel.is
