### PR TITLE
Require 'napa/version' in the CLI

### DIFF
--- a/lib/napa/cli.rb
+++ b/lib/napa/cli.rb
@@ -1,5 +1,6 @@
 require 'thor'
 require 'napa/generators'
+require 'napa/version'
 
 module Napa
   class CLI < Thor


### PR DESCRIPTION
`napa/version` doesn't actually get required by the CLI, so trying to run `napa version` from the command line results in an error:

```
/Users/david/.rubies/2.1.1/lib/ruby/gems/2.1.0/gems/napa-0.1.25/lib/napa/cli.rb:8:in `version': uninitialized constant Napa::VERSION (NameError)
    from /Users/david/.rubies/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /Users/david/.rubies/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /Users/david/.rubies/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
    from /Users/david/.rubies/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /Users/david/.rubies/2.1.1/lib/ruby/gems/2.1.0/gems/napa-0.1.25/bin/napa:5:in `<top (required)>'
    from /Users/david/.rubies/2.1.1/bin/napa:23:in `load'
    from /Users/david/.rubies/2.1.1/bin/napa:23:in `<main>'
```
