### PR TITLE
Remove hardcoding of mysql adapter

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -16,7 +16,6 @@ unless defined?(Rails)
     desc "Create the database"
     task :create => :environment do
       db = YAML.load(ERB.new(File.read('./config/database.yml')).result)[Napa.env]
-      adapter = db.merge({'database'=> 'mysql'})
       ActiveRecord::Base.establish_connection(adapter)
       ActiveRecord::Base.connection.create_database(db.fetch('database'))
     end
@@ -24,7 +23,6 @@ unless defined?(Rails)
     desc "Delete the database"
     task :drop => :environment do
       db = YAML.load(ERB.new(File.read('./config/database.yml')).result)[Napa.env]
-      adapter = db.merge({'database'=> 'mysql'})
       ActiveRecord::Base.establish_connection(adapter)
       ActiveRecord::Base.connection.drop_database(db.fetch('database'))
     end


### PR DESCRIPTION
Napa is somewhat mysql-centric, but it doesn't have to be. If you let the database.yml file specify `adapter: mysql`, then there is no reason to encode that into the db.rake. That will allow it to be used easily with other databases and leave the database.yml configuration to the user.
