### PR TITLE
treat bad data (unable to validate record) as a 400

### DIFF
--- a/lib/napa/grape_extenders.rb
+++ b/lib/napa/grape_extenders.rb
@@ -9,7 +9,7 @@ module Napa
           rack_response(Napa::JsonError.new(:record_not_found, 'record not found').to_json, 404)
         end
         modified_class.rescue_from ::ActiveRecord::RecordInvalid do |e|
-          rack_response(Napa::JsonError.new(:record_invalid, 'record not found').to_json, 500)
+          rack_response(Napa::JsonError.new(:record_invalid, 'record not found').to_json, 400)
         end
       end
     end


### PR DESCRIPTION
10.4.1 400 Bad Request

The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modifications.

@darbyfrey
