### PR TITLE
Better ActiveRecord exception handling

### DIFF
--- a/lib/napa/grape_extenders.rb
+++ b/lib/napa/grape_extenders.rb
@@ -9,7 +9,7 @@ module Napa
           rack_response(Napa::JsonError.new(:record_not_found, 'record not found').to_json, 404)
         end
         modified_class.rescue_from ::ActiveRecord::RecordInvalid do |e|
-          rack_response(Napa::JsonError.new(:record_invalid, 'record not found').to_json, 400)
+          rack_response(Napa::JsonError.new(:unprocessable_entity, e.message).to_json, 422)
         end
       end
     end


### PR DESCRIPTION
@jdoconnor 

I think it's more appropriate for a validation failure to return a `422 unprocessable_entity` for a validation failure. This updates the automated exception handling to produce that response.
