### PR TITLE
Adding "napa console" using racksh

### DIFF
--- a/lib/napa/cli.rb
+++ b/lib/napa/cli.rb
@@ -28,6 +28,25 @@ module Napa
         say Napa::VERSION
       end
 
+      desc 'console', 'Start the Napa console'
+      def console
+        require 'racksh/init'
+
+        begin
+          require "pry"
+          interpreter = Pry
+        rescue LoadError
+          require "irb"
+          require "irb/completion"
+          interpreter = IRB
+        end
+
+        Rack::Shell.init
+
+        $0 = "#{$0} console"
+        interpreter.start
+      end
+
       register(
         Generators::ScaffoldGenerator,
         'new',

--- a/lib/napa/generators/templates/scaffold/console
+++ b/lib/napa/generators/templates/scaffold/console
@@ -1,9 +1,0 @@
-require './app'
-
-begin
-  require 'pry'
-  Pry.start
-rescue LoadError
-  require 'irb/completion'
-  IRB.start
-end

--- a/napa.gemspec
+++ b/napa.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'grape-entity'
   gem.add_dependency 'unicorn'
   gem.add_dependency 'statsd-ruby'
+  gem.add_dependency 'racksh'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'pry'


### PR DESCRIPTION
https://github.com/sickill/racksh looks pretty cool. It solves for a lot of the things that have been lacking from the current console. This PR adds console as a napa command, so you can use `napa console` to load it.

@jdoconnor @dshemenski @skwp
