### PR TITLE
use camelize as to not singularize migrations ending in plurals

### DIFF
--- a/lib/napa/generators/migration_generator.rb
+++ b/lib/napa/generators/migration_generator.rb
@@ -15,10 +15,14 @@ module Napa
         "#{version}_#{migration_name.underscore}"
       end
 
+      def output_directory
+        './db/migrate'
+      end
+
       def migration
         self.class.source_root "#{File.dirname(__FILE__)}/templates/migration"
         say 'Generating migration...'
-        directory '.', './db/migrate'
+        directory '.', output_directory
         say 'Done!', :green
       end
     end

--- a/lib/napa/generators/templates/migration/%migration_filename%.rb.tt
+++ b/lib/napa/generators/templates/migration/%migration_filename%.rb.tt
@@ -1,4 +1,4 @@
-class <%= migration_name.classify %> < ActiveRecord::Migration
+class <%= migration_name.camelize %> < ActiveRecord::Migration
   def change
   end
 end

--- a/spec/generators/migration_generator_spec.rb
+++ b/spec/generators/migration_generator_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'napa/generators/migration_generator'
+require 'napa/cli'
+
+describe Napa::Generators::MigrationGenerator do
+
+  let(:migration_name) { 'foo_bars' }
+  let(:test_migrations_directory) { 'spec/tmp' }
+
+  before do
+    described_class.any_instance.stub(:output_directory) { test_migrations_directory }
+  end
+
+  after do
+    FileUtils.rm_rf(test_migrations_directory)
+  end
+
+  it 'creates a camelized migration class' do
+    described_class.any_instance.stub(:migration_filename) { 'foo' }
+    Napa::CLI::Base.new.generate("migration", migration_name)
+    expected_migration_file = File.join(test_migrations_directory, 'foo.rb')
+    migration_code = File.read(expected_migration_file)
+    expect(migration_code).to match(/class FooBars/)
+  end
+
+
+end


### PR DESCRIPTION
using classify will singlularize migrations that end in plurals, which then raise a constant not defined error when trying to run the migration. e.g.

```
napa generate migration foo_bars
```

generates

```
class FooBar < ActiveRecord::Migration
```

when we really want

```
class FooBars < ActiveRecord::Migration
```
