### PR TITLE
remove unicorn as gem dependency

### DIFF
--- a/napa.gemspec
+++ b/napa.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'grape'
   gem.add_dependency 'grape-swagger'
   gem.add_dependency 'roar'
-  gem.add_dependency 'unicorn'
   gem.add_dependency 'statsd-ruby'
   gem.add_dependency 'racksh'
 


### PR DESCRIPTION
I'm not sure if there is a specific reason this is included as a dependency of the gem, but it seems unnecessary and breaks compatibility with jRuby. It'd be nice to remove it and not force it upon users of the framework.
