### PR TITLE
No reason to require gems only used from command line.

### DIFF
--- a/lib/napa/generators/templates/scaffold/Gemfile.tt
+++ b/lib/napa/generators/templates/scaffold/Gemfile.tt
@@ -6,7 +6,6 @@ gem '<%= @database_gem %>'
 gem 'activerecord', '~> 4.0.0', :require => 'active_record'
 gem 'honeybadger'
 gem 'json'
-gem 'shotgun', require: false
 gem 'napa'
 gem 'roar'
 gem 'grape-swagger'
@@ -17,6 +16,7 @@ end
 
 group :development do
   gem 'rubocop', require: false
+  gem 'shotgun', require: false
 end
 
 group :test do


### PR DESCRIPTION
Both of these gems will be run from the command-line and shouldn't be automatically required by Bundler, which causes a tiny bit of unnecessary overhead.
