### PR TITLE
Data response includes `object_type` on index

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -238,6 +238,7 @@ All response from Napa include the `data` key. In this case, we see an array con
 {
   "data": [
     {
+      "object_type": "person",
       "id": 1,
       "name": "Darby Frey",
       "job_title": "Software Engineer",


### PR DESCRIPTION
Updating the docs to include `object_type` in the response.
