### PR TITLE
use PATH_INFO instead of REQUEST_PATH

### DIFF
--- a/lib/napa/middleware/app_monitor.rb
+++ b/lib/napa/middleware/app_monitor.rb
@@ -6,7 +6,7 @@ module Napa
       end
 
       def call(env)
-        if ["/health", "/health.json"].include? env['REQUEST_PATH']
+        if ["/health", "/health.json"].include? env['PATH_INFO']
           [200, { 'Content-type' => 'application/json' }, [Napa::Identity.health.to_json]]
         else
           @app.call(env)


### PR DESCRIPTION
I'm actually not completely positive about this, but my research seems to indicate that PATH_INFO is the standard key for the value that is being used here. When testing unicorn, it seems that PATH_INFO and REQUEST_PATH are equal, but using Trinidad (and possibly other app servers) I don't think there is a guarantee that REQUEST_PATH will be set properly.

http://rack.rubyforge.org/doc/SPEC.html
