### PR TITLE
Add permitted_params grape helper to DRY up code.

### DIFF
--- a/lib/napa/generators/templates/api/app/apis/%name_tableize%_api.rb.tt
+++ b/lib/napa/generators/templates/api/app/apis/%name_tableize%_api.rb.tt
@@ -4,7 +4,7 @@ class <%= name.classify.pluralize %>Api < Grape::API
     optional :ids, type: String, desc: 'comma separated <%= name.underscore %> ids'
   end
   get do
-    <%= name.underscore.tableize %> = <%= name.classify %>.filter(declared(params, include_missing: false))
+    <%= name.underscore.tableize %> = <%= name.classify %>.filter(permitted_params)
     represent <%= name.underscore.tableize %>, with: <%= name.classify %>Representer
   end
 
@@ -13,7 +13,7 @@ class <%= name.classify.pluralize %>Api < Grape::API
   end
 
   post do
-    <%= name.underscore %> = <%= name.classify %>.create(declared(params, include_missing: false))
+    <%= name.underscore %> = <%= name.classify %>.create(permitted_params)
     error!(present_error(:record_invalid, <%= name.underscore %>.errors.full_messages)) unless <%= name.underscore %>.errors.empty?
     represent <%= name.underscore %>, with: <%= name.classify %>Representer
   end
@@ -34,7 +34,7 @@ class <%= name.classify.pluralize %>Api < Grape::API
     put do
       # fetch <%= name.underscore %> record and update attributes.  exceptions caught in app.rb
       <%= name.underscore %> = <%= name.classify %>.find(params[:id])
-      <%= name.underscore %>.update_attributes!(declared(params, include_missing: false))
+      <%= name.underscore %>.update_attributes!(permitted_params)
       represent <%= name.underscore %>, with: <%= name.classify %>Representer
     end
   end

--- a/lib/napa/grape_extensions/grape_helpers.rb
+++ b/lib/napa/grape_extensions/grape_helpers.rb
@@ -14,6 +14,11 @@ module Napa
       Napa::JsonError.new(code, message)
     end
 
+    def permitted_params(options = {})
+      options = { include_missing: false }.merge(options)
+      declared(params, options)
+    end
+
     # extend all endpoints to include this
     Grape::Endpoint.send :include, self
   end


### PR DESCRIPTION
Covers the common case of wanting to filter params based on what is declared, without including missing ones.

Includes options to override include missing, exclude parent namespaces, or stringify.
