### PR TITLE
updates to work better with travis

### DIFF
--- a/lib/napa/generators/templates/scaffold/spec/spec_helper.rb
+++ b/lib/napa/generators/templates/scaffold/spec/spec_helper.rb
@@ -5,9 +5,12 @@ require 'rack/test'
 require 'simplecov'
 require 'factory_girl'
 
-FactoryGirl.definition_file_paths = %w{./spec/factories}
+FactoryGirl.definition_file_paths = %w(./spec/factories)
 FactoryGirl.find_definitions
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/spec\/.*/"
+  add_filter "/vendor\/.*/"
+end
 
 require './app'
 require 'database_cleaner'


### PR DESCRIPTION
@darbyfrey @kylecrum @voxtex

Travis was not correctly calculating the code coverage because by default, the vendor path (where it puts the gems) are included.  This fixes it so that we can use statements like 

``` ruby
# fail once the test coverage gets below an accepted amount
SimpleCov.minimum_coverage 95
```
