### PR TITLE
Fixes #94

### DIFF
--- a/lib/napa/generators/templates/api/spec/apis/%name_tableize%_api_spec.rb.tt
+++ b/lib/napa/generators/templates/api/spec/apis/%name_tableize%_api_spec.rb.tt
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+def app
+  ApplicationApi
+end
+
+describe <%= name.classify.pluralize %>Api do
+  include Rack::Test::Methods
+
+  describe 'e.g. GET, POST, PUT, etc.' do
+    it 'needs tests to be written!' do
+      pending('write tests for <%= name.classify.pluralize %>Api!')
+    end
+  end
+
+end

--- a/lib/napa/generators/templates/api/spec/models/%name_underscore%_spec.rb.tt
+++ b/lib/napa/generators/templates/api/spec/models/%name_underscore%_spec.rb.tt
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe <%= name.classify %> do
+
+  it 'needs tests to be written!' do
+    pending('write tests for <%= name.classify %>!')
+  end
+
+end

--- a/spec/generators/api_generator_spec.rb
+++ b/spec/generators/api_generator_spec.rb
@@ -15,30 +15,49 @@ describe Napa::Generators::ApiGenerator do
     FileUtils.rm_rf(test_api_directory)
   end
 
-  it 'creates an api class' do
-    expected_api_file = File.join(test_api_directory, 'app/apis/foos_api.rb')
-    api_code = File.read(expected_api_file)
+  describe 'app' do
+    it 'creates an api class' do
+      expected_api_file = File.join(test_api_directory, 'app/apis/foos_api.rb')
+      api_code = File.read(expected_api_file)
 
-    expect(api_code).to match(/class FoosApi/)
+      expect(api_code).to match(/class FoosApi/)
+    end
+
+    it 'creates a model class' do
+      expected_model_file = File.join(test_api_directory, 'app/models/foo.rb')
+      model_code = File.read(expected_model_file)
+
+      expect(model_code).to match(/class Foo/)
+    end
+
+    it 'creates a representer class' do
+      expected_representer_file = File.join(test_api_directory, 'app/representers/foo_representer.rb')
+      representer_code = File.read(expected_representer_file)
+
+      expect(representer_code).to match(/class FooRepresenter/)
+    end
+
+    it 'representers should inherit from Napa::Representer' do
+      representer_file = File.join(test_api_directory, 'app/representers/foo_representer.rb')
+      require "./#{representer_file}"
+      expect(FooRepresenter.superclass).to be(Napa::Representer)
+    end
   end
 
-  it 'creates a model class' do
-    expected_model_file = File.join(test_api_directory, 'app/models/foo.rb')
-    model_code = File.read(expected_model_file)
+  describe 'spec' do
+    it 'creates an api spec' do
+      expected_api_file = File.join(test_api_directory, 'spec/apis/foos_api_spec.rb')
+      api_code = File.read(expected_api_file)
 
-    expect(model_code).to match(/class Foo/)
+      expect(api_code).to match(/describe FoosApi/)
+    end
+
+    it 'creates a model spec' do
+      expected_model_file = File.join(test_api_directory, 'spec/models/foo_spec.rb')
+      model_code = File.read(expected_model_file)
+
+      expect(model_code).to match(/describe Foo/)
+    end
   end
 
-  it 'creates a representer class' do
-    expected_representer_file = File.join(test_api_directory, 'app/representers/foo_representer.rb')
-    representer_code = File.read(expected_representer_file)
-
-    expect(representer_code).to match(/class FooRepresenter/)
-  end
-
-  it 'representers should inherit from Napa::Representer' do
-    representer_file = File.join(test_api_directory, 'app/representers/foo_representer.rb')
-    require "./#{representer_file}"
-    expect(FooRepresenter.superclass).to be(Napa::Representer)
-  end
 end


### PR DESCRIPTION
This creates some spec templates when you generate an api.

Should it also generate passing specs for the api endpoints defined in `foo_api.rb`? It'd have to mount the api in `application_api.rb`, which I'm not sure if you expect the api to be live once you generate it.
