### PR TITLE
ignoring ruby-gemset and version because they will often attempt to auto...

### DIFF
--- a/lib/napa/generators/templates/scaffold/.gitignore.tt
+++ b/lib/napa/generators/templates/scaffold/.gitignore.tt
@@ -8,3 +8,5 @@ log/*
 tmp/*
 coverage
 !.keep
+.ruby-gemset
+.ruby-version


### PR DESCRIPTION
... set the RVM or rbenv environments, which is great in dev, but terrifying in production
@darbyfrey - you added these not too long ago, are you ok with ignoring them for git?
