### PR TITLE
Fix JSON ErrorFormatter with backtrace rescue_options.

### DIFF
--- a/lib/napa/grape_extensions/error_formatter.rb
+++ b/lib/napa/grape_extensions/error_formatter.rb
@@ -7,7 +7,7 @@ if defined?(Grape)
             result = message.is_a?(Napa::JsonError) ? message : Napa::JsonError.new(:api_error, message)
 
             if (options[:rescue_options] || {})[:backtrace] && backtrace && !backtrace.empty?
-              result = result.merge(backtrace: backtrace)
+              result = result.to_h.merge(backtrace: backtrace)
             end
             MultiJson.dump(result)
           end

--- a/spec/grape_extensions/error_formatter_spec.rb
+++ b/spec/grape_extensions/error_formatter_spec.rb
@@ -17,5 +17,13 @@ describe Grape::ErrorFormatter::Json do
       parsed['error']['code'].should eq('foo')
       parsed['error']['message'].should eq('bar')
     end
+
+    it 'adds the backtrace with rescue_option[:backtrace] specified' do
+      error = Grape::ErrorFormatter::Json.call('',
+                                               'backtrace',
+                                               rescue_options: {backtrace: true})
+      parsed = JSON.parse(error)
+      parsed['backtrace'].should eq('backtrace')
+    end
   end
 end


### PR DESCRIPTION
Use to_h to convert JsonError before merging.
Add spec to cover this case.
