### PR TITLE
Fix napa console when using IRB.

### DIFF
--- a/lib/napa/cli.rb
+++ b/lib/napa/cli.rb
@@ -30,8 +30,8 @@ module Napa
 
       desc 'console [environment]', 'Start the Napa console'
       options aliases: 'c'
-      def console(environment = 'development' )
-        ENV['RACK_ENV'] = environment
+      def console(environment = nil)
+        ENV['RACK_ENV'] = environment || 'development'
 
         require 'racksh/init'
 
@@ -42,6 +42,9 @@ module Napa
           require "irb"
           require "irb/completion"
           interpreter = IRB
+          # IRB uses ARGV and does not expect these arguments.
+          ARGV.delete('console')
+          ARGV.delete(environment) if environment
         end
 
         Rack::Shell.init


### PR DESCRIPTION
IRB was taking extra arguments, "console" and optionally the environment, when running `napa console <environment>`. IRB then interprets this as a script name and errors out. These arguments are now removed from ARGV before starting the interpreter.

Here's the exact flow of things that happen to break IRB:

1) `@CONF[:SCRIPT]` gets set to 'console' since it is the first argument.
https://github.com/ruby/ruby/blob/1aa54bebaf274bc08e72f9ad3854c7ad592c344a/lib/irb/init.rb#L218

2) Irb is initialized with `@CONF[:SCRIPT]` which is passed in as `input_method`.
https://github.com/ruby/ruby/blob/77a8010abddbbcf06bc2b5d423e0284b4e4ea4c8/lib/irb.rb#L383

3) Context interprets this as a file name and tries to read it.
https://github.com/ruby/ruby/blob/77a8010abddbbcf06bc2b5d423e0284b4e4ea4c8/lib/irb/context.rb#L85

Uncaught exception: No such file or directory @ rb_sysopen - console

Everything bombs. My fix is to just remove the arguments that are being passed into napa console, leaving the ability to still pass arguments to IRB if desired.

If i had to guess I would assume everyone uses pry and didn't notice this. Reproduce by removing the pry gem from a generated APIs Gemfile.
