### PR TITLE
convert all shoulds and stubs to expects, matching rspec 3 style

### DIFF
--- a/spec/authentication_spec.rb
+++ b/spec/authentication_spec.rb
@@ -5,8 +5,8 @@ describe Napa::Authentication do
   context '#password_header' do
     it "returns a password hash for the request header" do
       ENV['HEADER_PASSWORD'] = 'foo'
-      Napa::Authentication.password_header.class.should eq(Hash)
-      Napa::Authentication.password_header.should eq('Password' => 'foo')
+      expect(Napa::Authentication.password_header.class).to eq(Hash)
+      expect(Napa::Authentication.password_header).to eq('Password' => 'foo')
     end
 
     it 'raises when the HEADER_PASSWORD env var is not defined' do

--- a/spec/generators/api_generator_spec.rb
+++ b/spec/generators/api_generator_spec.rb
@@ -7,7 +7,7 @@ describe Napa::Generators::ApiGenerator do
   let(:test_api_directory) { 'spec/tmp' }
 
   before do
-    described_class.any_instance.stub(:output_directory) { test_api_directory }
+    allow_any_instance_of(described_class).to receive(:output_directory).and_return(test_api_directory)
     Napa::CLI::Base.new.generate("api", api_name)
   end
 

--- a/spec/generators/migration_generator_spec.rb
+++ b/spec/generators/migration_generator_spec.rb
@@ -8,7 +8,7 @@ describe Napa::Generators::MigrationGenerator do
   let(:test_migrations_directory) { 'spec/tmp' }
 
   before do
-    described_class.any_instance.stub(:output_directory) { test_migrations_directory }
+    allow_any_instance_of(described_class).to receive(:output_directory).and_return(test_migrations_directory)
   end
 
   after do
@@ -16,7 +16,7 @@ describe Napa::Generators::MigrationGenerator do
   end
 
   it 'creates a camelized migration class' do
-    described_class.any_instance.stub(:migration_filename) { 'foo' }
+    allow_any_instance_of(described_class).to receive(:migration_filename).and_return('foo')
     Napa::CLI::Base.new.generate("migration", migration_name)
     expected_migration_file = File.join(test_migrations_directory, 'foo.rb')
     migration_code = File.read(expected_migration_file)

--- a/spec/grape_extensions/error_formatter_spec.rb
+++ b/spec/grape_extensions/error_formatter_spec.rb
@@ -6,16 +6,16 @@ describe Grape::ErrorFormatter::Json do
     it 'returns an api_error for plain error messages' do
       error = Grape::ErrorFormatter::Json.call('test message', nil)
       parsed = JSON.parse(error)
-      parsed['error']['code'].should eq('api_error')
-      parsed['error']['message'].should eq('test message')
+      expect(parsed['error']['code']).to eq('api_error')
+      expect(parsed['error']['message']).to eq('test message')
     end
 
     it 'returns a specified error when given a Napa::JsonError object' do
       json_error = Napa::JsonError.new(:foo, 'bar')
       error = Grape::ErrorFormatter::Json.call(json_error, nil)
       parsed = JSON.parse(error)
-      parsed['error']['code'].should eq('foo')
-      parsed['error']['message'].should eq('bar')
+      expect(parsed['error']['code']).to eq('foo')
+      expect(parsed['error']['message']).to eq('bar')
     end
 
     it 'adds the backtrace with rescue_option[:backtrace] specified' do
@@ -23,7 +23,7 @@ describe Grape::ErrorFormatter::Json do
                                                'backtrace',
                                                rescue_options: {backtrace: true})
       parsed = JSON.parse(error)
-      parsed['backtrace'].should eq('backtrace')
+      expect(parsed['backtrace']).to eq('backtrace')
     end
   end
 end

--- a/spec/identity_spec.rb
+++ b/spec/identity_spec.rb
@@ -5,46 +5,46 @@ describe Napa::Identity do
   context '#name' do
     it "returns 'api-service' if no ENV['SERVICE_NAME'] is set" do
       ENV['SERVICE_NAME'] = nil
-      Napa::Identity.name.should == 'api-service'
+      expect(Napa::Identity.name).to eq('api-service')
     end
 
     it "returns the ENV['SERVICE_NAME'] when specified" do
       ENV['SERVICE_NAME'] = nil
       ENV['SERVICE_NAME'] = 'my-service'
-      Napa::Identity.name.should eq('my-service')
+      expect(Napa::Identity.name).to eq('my-service')
     end
   end
 
   context '#hostname' do
     it 'returns the value of the hostname system call and doesn\'t make a second system call' do
-      Napa::Identity.should_receive(:`).with('hostname').and_return('system-hostname')
-      Napa::Identity.hostname.should eq('system-hostname')
+      expect(Napa::Identity).to receive(:`).with('hostname').and_return('system-hostname')
+      expect(Napa::Identity.hostname).to eq('system-hostname')
 
-      Napa::Identity.should_not_receive(:`).with('hostname')
-      Napa::Identity.hostname.should eq('system-hostname')
+      expect(Napa::Identity).to_not receive(:`).with('hostname')
+      expect(Napa::Identity.hostname).to eq('system-hostname')
     end
   end
 
   context '#revision' do
     it 'returns the value of the \'git rev-parse HEAD\' system call and doesn\'t make a second system call' do
-      Napa::Identity.should_receive(:`).with('git rev-parse HEAD').and_return('12345')
-      Napa::Identity.revision.should eq('12345')
+      expect(Napa::Identity).to receive(:`).with('git rev-parse HEAD').and_return('12345')
+      expect(Napa::Identity.revision).to eq('12345')
 
-      Napa::Identity.should_not_receive(:`).with('git rev-parse HEAD')
-      Napa::Identity.revision.should eq('12345')
+      expect(Napa::Identity).to_not receive(:`).with('git rev-parse HEAD')
+      expect(Napa::Identity.revision).to eq('12345')
     end
   end
 
   context '#pid' do
     it 'returns the process ID value' do
-      Process.stub(:pid).and_return(112233)
-      Napa::Identity.pid.should be(112233)
+      allow(Process).to receive(:pid).and_return(112233)
+      expect(Napa::Identity.pid).to eq(112233)
     end
   end
 
   context '#platform_revision' do
     it 'returns the current version of the platform gem' do
-      Napa::Identity.platform_revision.should == Napa::VERSION
+      expect(Napa::Identity.platform_revision).to eq(Napa::VERSION)
     end
   end
 end

--- a/spec/json_error_spec.rb
+++ b/spec/json_error_spec.rb
@@ -7,8 +7,8 @@ describe Napa::JsonError do
       error = Napa::JsonError.new(:code, 'message').to_json
       parsed = JSON.parse(error)
 
-      parsed['error']['code'].should eq('code')
-      parsed['error']['message'].should eq('message')
+      expect(parsed['error']['code']).to eq('code')
+      expect(parsed['error']['message']).to eq('message')
     end
   end
 end

--- a/spec/logger/log_transaction_spec.rb
+++ b/spec/logger/log_transaction_spec.rb
@@ -10,25 +10,25 @@ describe Napa::LogTransaction do
     it 'returns the current transaction id if it has been set' do
       id = SecureRandom.hex(10)
       Thread.current[:napa_tid] = id
-      Napa::LogTransaction.id.should == id
+      expect(Napa::LogTransaction.id).to eq(id)
     end
 
     it 'sets and returns a new id if the transaction id hasn\'t been set' do
-      Napa::LogTransaction.id.should_not be_nil
+      expect(Napa::LogTransaction.id).to_not be_nil
     end
 
     it 'allows the id to be overridden by a setter' do
-      Napa::LogTransaction.id.should_not be_nil
+      expect(Napa::LogTransaction.id).to_not be_nil
       Napa::LogTransaction.id = 'foo'
-      Napa::LogTransaction.id.should == 'foo'
+      expect(Napa::LogTransaction.id).to eq('foo')
     end
   end
 
   context '#clear' do
     it 'sets the id to nil' do
-      Napa::LogTransaction.id.should_not be_nil
+      expect(Napa::LogTransaction.id).to_not be_nil
       Napa::LogTransaction.clear
-      Thread.current[:napa_tid].should be_nil
+      expect(Thread.current[:napa_tid]).to be_nil
     end
   end
 end

--- a/spec/middleware/authentication_spec.rb
+++ b/spec/middleware/authentication_spec.rb
@@ -14,7 +14,7 @@ describe Napa::Identity do
       env = Rack::MockRequest.env_for('/test', {'HTTP_PASSWORD' => 'foo'})
       status, headers, body = middleware.call(env)
 
-      status.should be(200)
+      expect(status).to eq(200)
     end
   end
 
@@ -25,8 +25,8 @@ describe Napa::Identity do
       env = Rack::MockRequest.env_for('/test')
       status, headers, body = middleware.call(env)
 
-      status.should be(401)
-      body.should eq([Napa::JsonError.new('bad_password', 'bad password').to_json])
+      expect(status).to eq(401)
+      expect(body).to eq([Napa::JsonError.new('bad_password', 'bad password').to_json])
     end
 
     it 'returns an error message if an incorrect Password header is supplied' do
@@ -35,8 +35,8 @@ describe Napa::Identity do
       env = Rack::MockRequest.env_for('/test', {'HTTP_PASSWORD' => 'incorrect'})
       status, headers, body = middleware.call(env)
 
-      status.should be(401)
-      body.should eq([Napa::JsonError.new('bad_password', 'bad password').to_json])
+      expect(status).to eq(401)
+      expect(body).to eq([Napa::JsonError.new('bad_password', 'bad password').to_json])
     end
 
     it 'returns an error message if HEADER_PASSWORDS is not configured' do
@@ -47,8 +47,8 @@ describe Napa::Identity do
       env = Rack::MockRequest.env_for('/test', {'HTTP_PASSWORD' => 'incorrect'})
       status, headers, body = middleware.call(env)
 
-      status.should be(401)
-      body.should eq([Napa::JsonError.new('not_configured', 'password not configured').to_json])
+      expect(status).to eq(401)
+      expect(body).to eq([Napa::JsonError.new('not_configured', 'password not configured').to_json])
     end
   end
 end

--- a/spec/middleware/request_stats_spec.rb
+++ b/spec/middleware/request_stats_spec.rb
@@ -10,8 +10,8 @@ describe Napa::Middleware::RequestStats do
   end
 
   it 'should increment api_requests counter' do
-    Napa::Stats.emitter.should_receive(:increment).with('request_count')
-    Napa::Stats.emitter.should_receive(:increment).with('path.get.test.path.request_count')
+    expect(Napa::Stats.emitter).to receive(:increment).with('request_count')
+    expect(Napa::Stats.emitter).to receive(:increment).with('path.get.test.path.request_count')
     app = lambda { |env| [200, { 'Content-Type' => 'application/json' }, Array.new] }
     middleware = Napa::Middleware::RequestStats.new(app)
     env = Rack::MockRequest.env_for('/test/path')
@@ -19,8 +19,8 @@ describe Napa::Middleware::RequestStats do
   end
 
   it 'should send the api_response_time' do
-    Napa::Stats.emitter.should_receive(:timing).with('response_time', an_instance_of(Float))
-    Napa::Stats.emitter.should_receive(:timing).with('path.get.test.path.response_time', an_instance_of(Float))
+    expect(Napa::Stats.emitter).to receive(:timing).with('response_time', an_instance_of(Float))
+    expect(Napa::Stats.emitter).to receive(:timing).with('path.get.test.path.response_time', an_instance_of(Float))
     app = lambda { |env| [200, { 'Content-Type' => 'application/json'}, Array.new] }
     middleware = Napa::Middleware::RequestStats.new(app)
     env = Rack::MockRequest.env_for('/test/path')

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -6,14 +6,14 @@ describe Napa::Stats do
     # Delete any prevous instantiations of the emitter
     Napa::Stats.emitter = nil
     # Stub out logging since there is no log to output to
-    Napa::Logger.stub_chain(:logger, :warn)
+    allow(Napa::Logger).to receive_message_chain(:logger, :warn)
   end
 
   it 'should log an error if StatsD env variables are not configured' do
     ENV['STATSD_HOST'] = nil
     ENV['STATSD_PORT'] = nil
     message = 'StatsD host and port not configured in environment variables, using default settings'
-    Napa::Logger.logger.should_receive(:warn).with(message)
+    expect(Napa::Logger.logger).to receive(:warn).with(message)
     Napa::Stats.emitter
   end
 

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -5,36 +5,36 @@ describe Napa::Version do
   context '#major_bump' do
     it 'should set the major revision value, and the rest should be 0' do
       stub_const('Napa::VERSION', '1.2.3')
-      Napa::Version.next_major.should == '2.0.0'
+      expect(Napa::Version.next_major).to eq('2.0.0')
     end
 
     it 'should set the major revision value, and the rest should be 0' do
       stub_const('Napa::VERSION', '5.0.0')
-      Napa::Version.next_major.should == '6.0.0'
+      expect(Napa::Version.next_major).to eq('6.0.0')
     end
   end
 
   context '#minor_bump' do
     it 'should set the minor revision value, leaving the major value unchanged and the patch value to 0' do
       stub_const('Napa::VERSION', '1.2.3')
-      Napa::Version.next_minor.should == '1.3.0'
+      expect(Napa::Version.next_minor).to eq('1.3.0')
     end
 
     it 'should set the minor revision value, leaving the major value unchanged and the patch value to 0' do
       stub_const('Napa::VERSION', '0.5.0')
-      Napa::Version.next_minor.should == '0.6.0'
+      expect(Napa::Version.next_minor).to eq('0.6.0')
     end
   end
 
   context 'patch_bump' do
     it 'should set the patch revision value, leaving the major and minor values unchanged' do
       stub_const('Napa::VERSION', '1.2.3')
-      Napa::Version.next_patch.should == '1.2.4'
+      expect(Napa::Version.next_patch).to eq('1.2.4')
     end
 
     it 'should set the patch revision value, leaving the major and minor values unchanged' do
       stub_const('Napa::VERSION', '5.5.5')
-      Napa::Version.next_patch.should == '5.5.6'
+      expect(Napa::Version.next_patch).to eq('5.5.6')
     end
   end
 end


### PR DESCRIPTION
RSpec 3 now `expect`s (see what I did there) a departure from the `should` and `stub` syntax, causing depreciation warnings when running the test suite:

> Deprecation Warnings:
> 
> Using `should_receive` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/trey/Developer/napa/spec/active_record_extensions/stats_spec.rb:28:in `block (2 levels) in <top (required)>'.
> 
> Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/trey/Developer/napa/spec/authentication_spec.rb:8:in `block (3 levels) in <top (required)>'.

I've gone through and converted the files that were raising the depreciation errors.
