### PR TITLE
also expose grape helpers as an active support concern for Rails

### DIFF
--- a/lib/napa/grape_extensions/grape_helpers.rb
+++ b/lib/napa/grape_extensions/grape_helpers.rb
@@ -20,6 +20,8 @@ module Napa
     end
 
     # extend all endpoints to include this
-    Grape::Endpoint.send :include, self
+    Grape::Endpoint.send :include, self if defined?(Grape)
+    # rails 4 controller concern
+    extend ActiveSupport::Concern if defined?(Rails)
   end
 end


### PR DESCRIPTION
Let's invite Rails to the party and include our GrapeHelpers as ActiveSupport Concerns, which makes them includable in controllers
@bellycard/platform @kylecrum
