### PR TITLE
Fixes #119

### DIFF
--- a/lib/tasks/routes.rake
+++ b/lib/tasks/routes.rake
@@ -2,9 +2,10 @@ unless defined?(Rails)
   desc "display all routes for Grape"
   task :routes do
     ApplicationApi.routes.each do |api|
-      method  = api.route_method.ljust(10)
-      path    = api.route_path
-      puts    "     #{method} #{path}"
+      method      = api.route_method.ljust(10)
+      path        = api.route_path.ljust(40)
+      description = api.route_description
+      puts        "     #{method} #{path} # #{description}"
     end
   end
 end


### PR DESCRIPTION
The `add_swagger_documentation` endpoints will display like so:

```
     GET        /swagger_doc(.:format)                   # Swagger compatible API description
     GET        /swagger_doc/:name(.:format)             # Swagger compatible API description for specific API
```
