### PR TITLE
Using find! instead of find

### DIFF
--- a/lib/napa/generators/templates/api/app/apis/%name_tableize%_api.rb.tt
+++ b/lib/napa/generators/templates/api/app/apis/%name_tableize%_api.rb.tt
@@ -23,7 +23,7 @@ class <%= name.classify.pluralize %>Api < Grape::API
   route_param :id do
     desc 'Get an <%= name.underscore %>'
     get do
-      <%= name.underscore %> = <%= name.classify %>.find(params[:id])
+      <%= name.underscore %> = <%= name.classify %>.find!(params[:id])
       represent <%= name.underscore %>, with: <%= name.classify %>Representer
     end
 
@@ -32,7 +32,7 @@ class <%= name.classify.pluralize %>Api < Grape::API
     end
     put do
       # fetch <%= name.underscore %> record and update attributes.  exceptions caught in app.rb
-      <%= name.underscore %> = <%= name.classify %>.find(params[:id])
+      <%= name.underscore %> = <%= name.classify %>.find!(params[:id])
       <%= name.underscore %>.update_attributes!(permitted_params)
       represent <%= name.underscore %>, with: <%= name.classify %>Representer
     end


### PR DESCRIPTION
Right now, the representers will error out when they try to render a `nil` object, which then returns a `500` error.

By using find!, we'll get `404`s instead of `500`s.
