### PR TITLE
Upgrade ActiveRecord dependency to ~> 4.1.0 in generated Gemfile.

### DIFF
--- a/lib/napa/generators/templates/scaffold/Gemfile.tt
+++ b/lib/napa/generators/templates/scaffold/Gemfile.tt
@@ -3,7 +3,7 @@ ruby "2.0.0"
 
 gem 'rack-cors'
 gem '<%= @database_gem %>'
-gem 'activerecord', '~> 4.0.0', :require => 'active_record'
+gem 'activerecord', '~> 4.1.0', :require => 'active_record'
 gem 'honeybadger'
 gem 'json'
 gem 'napa'


### PR DESCRIPTION
When running `bundle install` after generating a fresh scaffold, I get the following error:

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    activerecord (~> 4.0.0) ruby depends on
      activesupport (= 4.0.0) ruby

    grape-swagger (>= 0) ruby depends on
      grape (>= 0) ruby depends on
        activesupport (4.1.5)
```

Grape's gemspec doesn't specify a version for their ActiveSupport dependency, which now defaults to 4.1.5.  The Gemfile generated by the Napa scaffold specifies version ~> 4.0.0 for ActiveRecord.  Updating the template for the generated Gemfile fixes the version incompatibility.

(I imagine this will be a bigger issue when Grape's ActiveSupport dependency starts defaulting to 5.0.)
