### PR TITLE
I find these spec_helpers really useful

### DIFF
--- a/lib/napa/rspec_extensions/response_helpers.rb
+++ b/lib/napa/rspec_extensions/response_helpers.rb
@@ -12,6 +12,35 @@ module Napa
       def response_body
         last_response.body
       end
+      
+      def result_count
+        parsed_response.data.count
+      end
+
+      def first_result
+        parsed_response.data.first
+      end
+
+      def result_with_id(id)
+        parsed_response.data.select { |r| r.id == id }.first
+      end
+
+      def expect_count_of(count)
+        expect(result_count).to eq(count)
+      end
+
+      def expect_only(object)
+        expect_count_of 1
+        expect(first_result.id).to eq(object.id)
+      end
+
+      def expect_to_have(object)
+        expect(!!result_with_id(object.id)).to be_truthy
+      end
+
+      def expect_to_not_have(object)
+        expect(!!result_with_id(object.id)).to be_falsy
+      end
     end
   end
 end


### PR DESCRIPTION
I think it might be controversial, but I'm putting these in to start the conversation.  I've been using these to make my specs really dry.

``` ruby
context 'searching for foos' do
  before do
    @foo_a = FactoryGirl.create :foo, bar: true
    @foo_b = FactoryGirl.create :foo, bar: false
  end
  it 'returns all foos' do
    get '/foos'
    expect_count_of 2
  end
  it 'allows filtering foos by bar' do
    get '/foos', bar: true
    expect_to_have @foo_a
    expect_to_not_have @foo_b
  end
  it 'returns only the requested foo' do
    get "/foos/#{@foo_a.id}"
    expect_only @foo_a
  end
end
```
