### PR TITLE
Disable Napa::Middleware::Authentication by default

### DIFF
--- a/lib/napa/generators/templates/scaffold/.env.test.tt
+++ b/lib/napa/generators/templates/scaffold/.env.test.tt
@@ -1,3 +1,6 @@
+# Uncomment when using Napa::Middleware::Authentication
+# HEADER_PASSWORD=''
+
 SERVICE_NAME=<%= app_name %>
 RACK_ENV=test
 

--- a/lib/napa/generators/templates/scaffold/.env.tt
+++ b/lib/napa/generators/templates/scaffold/.env.tt
@@ -1,3 +1,6 @@
+# Uncomment when using Napa::Middleware::Authentication
+# HEADER_PASSWORD=''
+
 SERVICE_NAME=<%= app_name %>
 
 DATABASE_USER='<%= @database_user %>'

--- a/lib/napa/generators/templates/scaffold/config.ru.tt
+++ b/lib/napa/generators/templates/scaffold/config.ru.tt
@@ -14,7 +14,8 @@ require './app'
 # use Napa::Middleware::Logger
 
 use Napa::Middleware::AppMonitor
-use Napa::Middleware::Authentication
+# Uncomment to require header passwords for all requestss
+# use Napa::Middleware::Authentication
 use ActiveRecord::ConnectionAdapters::ConnectionManagement
 
 run ApplicationApi


### PR DESCRIPTION
Closes #152 
- Adds commented out `HEADER_PASSWORD=` to .env files
- Commented out `Napa::Middleware::Authentication` with note about it's usefulness. 

@bellycard/platform @craigulliott 
