### PR TITLE
cleaning up gemspec

### DIFF
--- a/napa.gemspec
+++ b/napa.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["darby@bellycard.com"]
   gem.description   = %q{A simple framework for building APIs with Grape}
   gem.summary       = %q{A rack-based framework wrapping around the Grape REST-like framework for Ruby.}
-  gem.homepage      = "http://tech.bellycard.com"
+  gem.homepage      = "https://tech.bellycard.com"
   gem.licenses      = ['MIT']
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
Cleans up gemspec by adding version dependencies, license, homepage, and summary.

Now it's clean when building! Fixes https://github.com/bellycard/napa/issues/130.

```
> gem build napa.gemspec
  Successfully built RubyGem
  Name: napa
  Version: 0.4.0
  File: napa-0.4.0.gem
```

@bellycard/platform 
