### PR TITLE
Use database configuration for creating and dropping databases

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -27,6 +27,9 @@ unless defined?(Rails)
       options = {}.tap do |o|
         o[:adapter]                 = db['adapter']
         o[:database]                = 'postgres' if db['adapter'] == 'postgresql'
+        %w(host port username password).each do |f|
+          o[f.to_sym] = db[f] if db.has_key? f
+        end
       end
 
       ActiveRecord::Base.establish_connection(options)
@@ -41,6 +44,9 @@ unless defined?(Rails)
       options = {}.tap do |o|
         o[:adapter]                 = db['adapter']
         o[:database]                = 'postgres' if db['adapter'] == 'postgresql'
+        %w(host port username password).each do |f|
+          o[f.to_sym] = db[f] if db.has_key? f
+        end
       end
 
       ActiveRecord::Base.establish_connection(options)


### PR DESCRIPTION
Discovered this while trying to use Napa with postgres on a non-standard port. This patch solved my issues.