### PR TITLE
Don't include error.reasons if none given

### DIFF
--- a/lib/napa/json_error.rb
+++ b/lib/napa/json_error.rb
@@ -17,7 +17,7 @@ module Napa
           message: @message
         }
       }
-      e[:error][:reasons] = @reasons if @reasons
+      e[:error][:reasons] = @reasons if @reasons.present?
       e
     end
   end

--- a/spec/json_error_spec.rb
+++ b/spec/json_error_spec.rb
@@ -20,5 +20,14 @@ describe Napa::JsonError do
       expect(parsed['error']['reasons']['foo']).to eq('bar')
     end
 
+    it 'excludes `reasons` from hash if no reasons given' do
+      error = Napa::JsonError.new(:code, 'message').to_json
+      parsed = JSON.parse(error)
+
+      expect(parsed['error']['code']).to eq('code')
+      expect(parsed['error']['message']).to eq('message')
+      expect(parsed['error']['reasons']).to be nil
+    end
+
   end
 end


### PR DESCRIPTION
@bellycard/platform 

When returning an error, the `reasons` key is always present, even if there is no data. 

**current**

```
GET /foo/bar
HTTP/1.1 400 Bad Request 
Server: nginx/1.6.2
Date: Tue, 09 Dec 2014 19:02:20 GMT
Content-Type: application/json
Content-Length: 86
Connection: close

{"error":{"code":"error_code","message":"Error message.","reasons":{}}}
```

This will check if there is any data present in the `reasons` attribute, and exclude it if there is none given. 

**fixed**

```
GET /foo/bar
HTTP/1.1 400 Bad Request 
Server: nginx/1.6.2
Date: Tue, 09 Dec 2014 19:02:20 GMT
Content-Type: application/json
Content-Length: 86
Connection: close

{"error":{"code":"error_code","message":"Error message."}}
```
