### PR TITLE
Add a sampling rate to StatsD timer

### DIFF
--- a/lib/napa/stats_d_timer.rb
+++ b/lib/napa/stats_d_timer.rb
@@ -1,15 +1,19 @@
 module Napa
   module StatsDTimer
-    def report_time(timer_name)
-      start_time = Time.now
-      yield
-      response_time = (Time.now - start_time) * 1000 # statsd reports timers in milliseconds
-      Napa::Stats.emitter.timing(timer_name, response_time)
+    def report_time(timer_name, sample_rate: 1)
+      if (Time.now.to_f * 1000).to_i % sample_rate == 0
+        start_time = Time.now
+        yield
+        response_time = (Time.now - start_time) * 1000 # statsd reports timers in milliseconds
+        Napa::Stats.emitter.timing(timer_name, response_time)
+      else
+        yield
+      end
     end
 
     module ClassMethods
-      def report_time(timer_name)
-        new.report_time(timer_name) do
+      def report_time(timer_name, sample_rate: 1)
+        new.report_time(timer_name, sample_rate: sample_rate) do
           yield
         end
       end


### PR DESCRIPTION
@bellycard/platform @bellycard/data 

When measuring very fast jobs, the act of timing can have an impact on the method. This pull adds a sampling rate option of when to track. 

``` ruby
report_time('metric', sample_rate: 10) do
  # your awesome code gets sampled every 10 milliseconds
end
```

If you don't pass in a `sample_rate`, it defaults to 1. A `sample_rate` of `x` means every `1:x` milliseconds will get logged.
