### PR TITLE
Sanitize params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 master
 ===
-* added a reasons object to error responses to represent active record validation errors for individual attributes 
+* Added a reasons object to error responses to represent active record validation errors for individual attributes
+* Added ability to filter sensitive data from logs.
 
 0.4.0
 ===
@@ -14,7 +15,7 @@ master
 * Added initialization hook to run code when a Napa service boots
 * Added Migration generators from Rails
 * Added rake db:seed functionality
-* Added some convinience methods to spec_helper
+* Added some convenience methods to spec_helper
 
 0.3.0
 ===

--- a/README.md
+++ b/README.md
@@ -129,6 +129,27 @@ ActiveRecord::Base.logger = Napa::Logger.logger
 ```ruby
 Napa::Logger.logger.debug 'Some Debug Message'
 ```
+
+### Scrubbing Logs of Sensitive Data
+
+Some requests may contain sensitive information, such as passwords or credit card numbers. In order to protect this information, they should be filtered out from logs.
+
+To do so, add the following line to an initializer:
+```ruby
+Napa::ParamSanitizer.filter_params = [:password, :password_confirmation, :cvv, :card_number]
+```
+Note that the keys in the array above are just examples. They should be replaced with the parameters that have sensitive data in their value.
+
+Example **unfiltered** request ( ... denotes other information):
+```
+{ ... "message":{"request":{"method":"POST","path":"/example","query":"name=Test%20User%200039\u0026password=password", ... "params":{"name":"Test User 0039","password":"password"} ...}}}
+```
+
+Example **filtered** request ( ... denotes other information):
+```
+{ ... "message":{"request":{"method":"POST","path":"/example","query":"name=Test%20User%200039\u0026password=[FILTERED]", ... "params":{"name":"Test User 0039","password":"[FILTERED]"} ...}}}
+```
+
 ### StatsD
 There are two middlewares available to enable StatsD reporting, `RequestStats` and `DatabaseStats`. They can be enabled independently in your `config.ru` file:
 

--- a/lib/napa/param_sanitizer.rb
+++ b/lib/napa/param_sanitizer.rb
@@ -1,0 +1,30 @@
+require 'action_dispatch'
+
+module Napa
+  module ParamSanitizer
+    include ActionDispatch::Http::FilterParameters
+
+    mattr_accessor :filter_params
+
+    KV_REGEXP   = '[^&;=]+'
+    PAIR_REGEXP = %r{(#{KV_REGEXP})=(#{KV_REGEXP})}
+
+    def filter_params
+      @@filter_params || []
+    end
+
+    def parameter_filter
+      parameter_filter_for(filter_params)
+    end
+
+    def filtered_parameters(params)
+      parameter_filter.filter(params)
+    end
+
+    def filtered_query_string(query_string)
+      query_string.gsub(PAIR_REGEXP) do |_|
+        parameter_filter.filter([[$1, $2]]).first.join("=")
+      end
+    end
+  end
+end

--- a/napa.gemspec
+++ b/napa.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'statsd-ruby', '~> 1.2'
   gem.add_dependency 'racksh', '~> 1.0'
   gem.add_dependency 'git', '~> 1.2'
+  gem.add_dependency 'actionpack', '>= 3.2'
 
   gem.add_development_dependency 'rspec', '~> 3.1'
   gem.add_development_dependency 'pry', '~> 0.10'


### PR DESCRIPTION
Allows us to sanitize params from our logs. `filter_params` is configurable (see below)

Makes use of ActionDispatch::Http::FilterParameters. 

@bellycard/platform 

----
Usage: In `config/initializers/logger.rb`, add this line:
```ruby
Napa::ParamSanitizer.filter_params = [:password, :card_number, :cvv, :password_confirmation]
```
Replace array with the parameters that you want filtered out from your logs