### PR TITLE
Hey! Spec suite! Leave them streams alone!

### DIFF
--- a/spec/generators/api_generator_spec.rb
+++ b/spec/generators/api_generator_spec.rb
@@ -6,6 +6,8 @@ describe Napa::Generators::ApiGenerator do
   let(:api_name) { 'foo' }
   let(:test_api_directory) { 'spec/tmp' }
 
+  tell_me_mr_odinson_what_good_is_a_phone_call_if_youre_unable_to_speak?
+
   before do
     allow_any_instance_of(described_class).to receive(:output_directory).and_return(test_api_directory)
     Napa::CLI::Base.new.generate("api", api_name)

--- a/spec/generators/migration_generator_spec.rb
+++ b/spec/generators/migration_generator_spec.rb
@@ -3,9 +3,10 @@ require 'napa/generators/migration_generator'
 require 'napa/cli'
 
 describe Napa::Generators::MigrationGenerator do
-
   let(:migration_filename) { 'foo' }
   let(:test_migrations_directory) { 'spec/tmp' }
+
+  tell_me_mr_odinson_what_good_is_a_phone_call_if_youre_unable_to_speak?
 
   before do
     allow_any_instance_of(described_class).to receive(:output_directory).and_return(test_migrations_directory)
@@ -100,6 +101,6 @@ describe Napa::Generators::MigrationGenerator do
     end
   end
 
-  describe 
+  describe
 
 end

--- a/spec/generators/readme_generator_spec.rb
+++ b/spec/generators/readme_generator_spec.rb
@@ -5,6 +5,8 @@ require 'napa/cli'
 describe Napa::Generators::ReadmeGenerator do
   let(:test_readme_directory) { 'spec/tmp' }
 
+  tell_me_mr_odinson_what_good_is_a_phone_call_if_youre_unable_to_speak?
+
   before do
     allow_any_instance_of(described_class).to receive(:output_directory).and_return(test_readme_directory)
     Napa::CLI::Base.new.generate("readme")

--- a/spec/generators/scaffold_generator_spec.rb
+++ b/spec/generators/scaffold_generator_spec.rb
@@ -7,6 +7,8 @@ describe Napa::Generators::ScaffoldGenerator do
   let(:app_path) { 'spec/my_different_directory' }
   let(:options) { {} }
 
+  tell_me_mr_odinson_what_good_is_a_phone_call_if_youre_unable_to_speak?
+
   before do
     scaffold = Napa::CLI::Base.new(args, options)
     scaffold.invoke(:new)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require 'napa/setup'
 require 'acts_as_fu'
 
 require "codeclimate-test-reporter"
-CodeClimate::TestReporter.configuration.logger = Logger.new('/dev/null')
 CodeClimate::TestReporter.start
 
 Napa.skip_initialization = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'napa/setup'
 require 'acts_as_fu'
 
 require "codeclimate-test-reporter"
+CodeClimate::TestReporter.configuration.logger = Logger.new('/dev/null')
 CodeClimate::TestReporter.start
 
 Napa.skip_initialization = true
@@ -11,35 +12,29 @@ Napa.skip_initialization = true
 require 'napa'
 require 'napa/rspec_extensions/response_helpers'
 
-# from https://gist.github.com/adamstegman/926858
-RSpec.configure do |config|
-  config.include Napa::RspecExtensions::ResponseHelpers
-
-  config.before(:all) { silence_output }
-  config.after(:all) { enable_output }
-
-  config.include ActsAsFu
-
-  config.before(:each) do
-    allow(Napa).to receive(:initialize)
-    allow(Napa::Logger).to receive_message_chain('logger.info').with(:napa_deprecation_warning)
+module NapaSpecClassHelpers
+  # Apparently Thor's last name is Odinson... who knew?!
+  # http://marvel.com/universe/Thor_(Thor_Odinson)
+  # http://www.infinitelooper.com/?v=4D7cPH7DHgA#/170;230
+  def tell_me_mr_odinson_what_good_is_a_phone_call_if_youre_unable_to_speak?
+    before do |spec|
+      allow_any_instance_of(Thor::Shell::Basic)
+        .to receive(:stdout).and_return(object_spy $stdout)
+      allow_any_instance_of(Thor::Shell::Basic)
+        .to receive(:stderr).and_return(object_spy $stderr)
+    end
   end
 end
 
-# Redirects stderr and stdout to /dev/null.
-def silence_output
-  @orig_stderr = $stderr
-  @orig_stdout = $stdout
+ActiveRecord::Schema.verbose = false
 
-  # redirect stderr and stdout to /dev/null
-  $stderr = File.new('/dev/null', 'w')
-  $stdout = File.new('/dev/null', 'w')
-end
+# from https://gist.github.com/adamstegman/926858
+RSpec.configure do |config|
+  config.include Napa::RspecExtensions::ResponseHelpers
+  config.extend  NapaSpecClassHelpers
+  config.include ActsAsFu
 
-# Replace stdout and stderr so anything else is output correctly.
-def enable_output
-  $stderr = @orig_stderr
-  $stdout = @orig_stdout
-  @orig_stderr = nil
-  @orig_stdout = nil
+  config.before(:each) do
+    allow(Napa::Logger).to receive_message_chain('logger.info').with(:napa_deprecation_warning)
+  end
 end


### PR DESCRIPTION
Apparently this https://gist.github.com/adamstegman/926858 was to get
RSpec to stfu. But now it calmed down again, so not necessary.
And it affects other things, like swallowing print statements,
causing pry to omit output, and hiding other output that is potentially
legitimate.

However, one nice side effect was that it caught other loudmouths in the dragnet:

* ActiveRecord::Migration, apparently there is a globaly flag you set to
  tell it to shush.
* Thor::Shell... I gave up on this one. Had tried passing in `shell`
  like any sensible interface, but it was blowing up pretty hard. Had
  tried wiping out here https://github.com/erikhuda/thor/blob/53b3fc89ce750258e19c53b1a99b32dd5941451a/lib/thor/shell.rb#L6
  but it's passing around classes instead of instances, so its like you
  have to have layers on layers of fake classes. Tried passing it here
  https://github.com/erikhuda/thor/blob/53b3fc89ce750258e19c53b1a99b32dd5941451a/lib/thor/shell.rb#L53
  but the indirection of who'se inheriting from whom and calling what on
  what and which vars got set by whatever wherever were just too much
  for me at this hour, so fuck it. Stub it.
* CodeClimate is logging directly to stderr. You can get it to stfu with:
  `CodeClimate::TestReporter.configuration.logger = Logger.new('/dev/null')`
  Put it before the `CodeClimate::TestReporter.start` I didn't do it b/c
  it was doing this before (it runs before output streams were silenced)
  so I figured maybe someone wanted it that way on purpose. Plus, you
  probably do want it logging in CI, which you'd probably do by setting an
  env var there, and then silencing it unless you see the var. Since I
  don't have access to your CI, and getting all that config wired up
  right tends to be fragile, I figured it'd be best to leave it.

Went with a matrix theme, b/c the vindictive side of me enjoyed the idea
of Thor's stupid mouth getting melted shut.