### PR TITLE
Default rake task runs specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,9 @@
 #!/usr/bin/env rake
+$LOAD_PATH.unshift 'lib', __dir__
+
 Dir.glob('./tasks/*.rake').each { |r| import r }
 require 'bundler/gem_tasks'
 require 'napa/active_record_extensions/stats.rb'
 require 'napa/active_record_extensions/seeder.rb'
+
+task default: :spec

--- a/tasks/spec.rake
+++ b/tasks/spec.rake
@@ -1,0 +1,9 @@
+desc 'Run the RSpec test suite'
+task :spec do
+  sh *%w[
+    bundle exec
+      rspec --colour
+            --format documentation
+            --fail-fast
+  ]
+end


### PR DESCRIPTION
Highly common for Ruby libs to set the default rake task to run the test
suite. It's the first thing I do when looking at an app. Since its not
being used for anything else, figured I'd send a PR to add it.

* Fix load path before requiring files so that user can type `rake`
  without worrying about Bundler. Otherwise, it fails because it can't
  find the napa files. Note that not doing this runs the risk of
  invoking rake without Bundler and accidentally requiring the files
  from the napa that is installed in your rubygems. Ie those files coming
  from installed version, and other files coming from the dev lib.
  If they sufficiently diverge on a dev's computer, it could cause a
  bug that costs the dev a lot of time and frustration.
* Add `rake spec` task to run the test suite. I added my preferred
  options, but modify them at will (figured it was fine since
  .travis.yml was setting colour)
* Set the default task to depend on the spec task.