### PR TITLE
Explicitly require `filter_parameters.rb` instead of relying on `action_dispatch` autoload

### DIFF
--- a/lib/napa/param_sanitizer.rb
+++ b/lib/napa/param_sanitizer.rb
@@ -1,4 +1,4 @@
-require 'action_dispatch'
+require 'action_dispatch/http/filter_parameters'
 
 module Napa
   module ParamSanitizer


### PR DESCRIPTION
In `action_pack` 4.1 autoloading of FilterParameters was removed from `action_dispatch` (https://github.com/rails/rails/commit/8d7923b7eb0dd638d1426aadde2b2d9835ecf68d)

This change fixes an exception that is raised at application load time when using napa in a Rails >= 4.1 application.