### PR TITLE
Fixing Honeybadger rake tasks requiring

### DIFF
--- a/lib/napa/generators/templates/scaffold/config/middleware/honeybadger.rb
+++ b/lib/napa/generators/templates/scaffold/config/middleware/honeybadger.rb
@@ -1,4 +1,4 @@
-require 'honeybadger/rake_handler'
+require 'honeybadger/tasks'
 
 Honeybadger.configure do |config|
   config.rescue_rake_exceptions = true


### PR DESCRIPTION
It looks like the RakeHandler was removed from honeybadger-ruby in 2.x
in favor of native requiring in Rails. Outside of Rails you just have
to manually require the tasks.