### PR TITLE
allow authentication to receive multiple and accept multiple passwords

### DIFF
--- a/lib/napa/middleware/authentication.rb
+++ b/lib/napa/middleware/authentication.rb
@@ -25,7 +25,10 @@ module Napa
       end
 
       def authenticated_request?(env)
-        @allowed_passwords.include? env['HTTP_PASSWORD'] unless @allowed_passwords.nil?
+        return if @allowed_passwords.nil?
+        possible_passwords = env['HTTP_PASSWORD'].to_s.split(',')
+        return if possible_passwords.length > 2
+        (@allowed_passwords & possible_passwords).any?
       end
     end
   end


### PR DESCRIPTION
@bellycard/platform @darbyfrey @danielmackey 

This is allows us to have a way to switch the HEADER_PASSWORD easily.

This also might be a __breaking change__ if you use a HEADER_PASSWORD that has a comma in it. Let me know if that's the case.

Let me know how you feel about the `possible_passwords` being limited to 2 choices. I figured it'd be a bad idea to allow a large number of `possible_passwords` being passed.