### PR TITLE
Fix bug preventing db rake tasks from running on remote servers

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -24,7 +24,7 @@ unless defined?(Rails)
     task :create => :environment do
       db = YAML.load(ERB.new(File.read('./config/database.yml')).result)[Napa.env]
 
-      options = {}.tap do |o|
+      options = db.tap do |o|
         o[:adapter]                 = db['adapter']
         o[:database]                = 'postgres' if db['adapter'] == 'postgresql'
       end
@@ -38,7 +38,7 @@ unless defined?(Rails)
     task :drop => :environment do
       db = YAML.load(ERB.new(File.read('./config/database.yml')).result)[Napa.env]
 
-      options = {}.tap do |o|
+      options = db.tap do |o|
         o[:adapter]                 = db['adapter']
         o[:database]                = 'postgres' if db['adapter'] == 'postgresql'
       end


### PR DESCRIPTION
This fixes the db rake tasks so that they work on remote servers by using the database.yml options.