### PR TITLE
Adds hashie-forbidden_attributes gem to default set to correct ForbiddenAttributesError

### DIFF
--- a/lib/napa/cli/templates/new/Gemfile.tt
+++ b/lib/napa/cli/templates/new/Gemfile.tt
@@ -4,6 +4,7 @@ ruby "2.0.0"
 gem 'rack-cors'
 gem '<%= @database_gem %>'
 gem 'activerecord', '~> 4.0.0', :require => 'active_record'
+gem 'hashie-forbidden_attributes'
 gem 'honeybadger', '~> 1.16.7'
 gem 'json'
 gem 'napa'


### PR DESCRIPTION
Corrects issue https://github.com/bellycard/napa/issues/205. Without this users that go through the steps outlined in the Quickstart Guide will hit a ForbiddenAttributesError when they submit the POST to create their first person record.