### PR TITLE
Heroku changes

### DIFF
--- a/lib/napa/identity.rb
+++ b/lib/napa/identity.rb
@@ -20,7 +20,7 @@ module Napa
     end
 
     def self.revision
-      @revision ||= if ENV['DYNO']
+      @revision ||= if Napa.heroku?
           ENV['GITSHA']
         else
           `git rev-parse HEAD`.strip

--- a/lib/napa/identity.rb
+++ b/lib/napa/identity.rb
@@ -20,7 +20,11 @@ module Napa
     end
 
     def self.revision
-      @revision ||= `git rev-parse HEAD`.strip
+      @revision ||= if ENV['DYNO']
+          ENV['GITSHA']
+        else
+          `git rev-parse HEAD`.strip
+        end
     end
 
     def self.pid

--- a/lib/napa/logger/configuration.rb
+++ b/lib/napa/logger/configuration.rb
@@ -4,7 +4,7 @@ module Napa
 
       def initialize(options = {})
         @options = {}.tap do |o|
-          o[:format] = :basic if Napa.env.development?
+          o[:format] = :basic if Napa.env.development? || ENV['DYNO']
           o[:output] = [:stdout] if ENV['DYNO']
         end
 

--- a/lib/napa/logger/configuration.rb
+++ b/lib/napa/logger/configuration.rb
@@ -4,8 +4,8 @@ module Napa
 
       def initialize(options = {})
         @options = {}.tap do |o|
-          o[:format] = :basic if Napa.env.development? || ENV['DYNO']
-          o[:output] = [:stdout] if ENV['DYNO']
+          o[:format] = :basic if Napa.env.development? || Napa.heroku?
+          o[:output] = [:stdout] if Napa.heroku?
         end
 
         @options.merge!(options)

--- a/lib/napa/setup.rb
+++ b/lib/napa/setup.rb
@@ -36,5 +36,9 @@ module Napa
     def lookup_env
       ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'development'
     end
+
+    def heroku?
+      !!ENV['DYNO']
+    end
   end
 end

--- a/spec/identity_spec.rb
+++ b/spec/identity_spec.rb
@@ -26,12 +26,22 @@ describe Napa::Identity do
   end
 
   context '#revision' do
+    before do
+      Napa::Identity.instance_variable_set :@revision, nil
+    end
+
     it 'returns the value of the \'git rev-parse HEAD\' system call and doesn\'t make a second system call' do
       expect(Napa::Identity).to receive(:`).with('git rev-parse HEAD').and_return('12345')
       expect(Napa::Identity.revision).to eq('12345')
 
       expect(Napa::Identity).to_not receive(:`).with('git rev-parse HEAD')
       expect(Napa::Identity.revision).to eq('12345')
+    end
+
+    it 'returns the value of ENV[\'GITSHA\'] if in the Heroku environment' do
+      allow(ENV).to receive(:[]).with("DYNO").and_return("foo")
+      allow(ENV).to receive(:[]).with("GITSHA").and_return("98765")
+      expect(Napa::Identity.revision).to eq('98765')
     end
   end
 

--- a/spec/logger/configuration_spec.rb
+++ b/spec/logger/configuration_spec.rb
@@ -18,6 +18,12 @@ describe Napa::Logger::Configuration do
       config = Napa::Logger::Configuration.new
       expect(config.format).to eq(:basic)
     end
+
+    it 'returns basic if in the Heroku environment' do
+      allow(ENV).to receive(:[]).with("DYNO").and_return("foo")
+      config = Napa::Logger::Configuration.new
+      expect(config.format).to eq(:basic)
+    end
   end
 
   describe '#output' do


### PR DESCRIPTION
* The Heroku Logplex doesn't support logging to JSON format, this change defaults Napa to use the :basic format when on Heroku.
* When a slug is built for Heroku it strips out all the git information, so we don't have access to git to find the current sha. This change remove the call to git and returns the value from an ENV which can be set during a post commit hook if desired. Alternately, since the sha is easily accessible in other ways in Heroku it may not be necessary to include in the health check payload.

@bellycard/platform 