### PR TITLE
Fix logging bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 master
 ===
+* [Fix for Logging bug in :basic format](https://github.com/bellycard/napa/pull/222)
 
 0.5.1
 ===

--- a/lib/napa/logger/logger.rb
+++ b/lib/napa/logger/logger.rb
@@ -49,7 +49,7 @@ module Napa
         {
           status:   status,
           headers:  headers,
-          response: body.first
+          response: body.try(:first)
         }.map { |k, v| "#{k}=#{v}" }.join(' ')
       end
 

--- a/spec/logger/logger_spec.rb
+++ b/spec/logger/logger_spec.rb
@@ -61,6 +61,12 @@ describe Napa::Logger do
 
       expect(response).to eq('status=foo headers=bar response=baz')
     end
+
+    it 'returns an acceptable response if body is nil' do
+      response = Napa::Logger.basic_response_format('foo', 'bar', nil)
+
+      expect(response).to eq('status=foo headers=bar response=')
+    end
   end
 
   describe '#hash_response_format' do


### PR DESCRIPTION
There are some cases where the response body will come back as nil. In this case I discovered it with a failure in the authentication middleware. This change fixes the logger to handle that case correctly.

@bellycard/platform 