### PR TITLE
read gitsha from file created during slug build

### DIFF
--- a/lib/napa/identity.rb
+++ b/lib/napa/identity.rb
@@ -21,7 +21,7 @@ module Napa
 
     def self.revision
       @revision ||= if Napa.heroku?
-          ENV['GITSHA']
+          File.exist?('.gitsha') ? File.read('.gitsha').gsub(/[^0-9a-z ]/i, '') : ''
         else
           `git rev-parse HEAD`.strip
         end

--- a/spec/identity_spec.rb
+++ b/spec/identity_spec.rb
@@ -38,10 +38,16 @@ describe Napa::Identity do
       expect(Napa::Identity.revision).to eq('12345')
     end
 
-    it 'returns the value of ENV[\'GITSHA\'] if in the Heroku environment' do
+    it 'returns the value of .gitsha if in the Heroku environment if file exists' do
       allow(ENV).to receive(:[]).with("DYNO").and_return("foo")
-      allow(ENV).to receive(:[]).with("GITSHA").and_return("98765")
+      allow(File).to receive(:exist?).with('.gitsha').and_return(true)
+      allow(File).to receive(:read).with('.gitsha').and_return('98765')
       expect(Napa::Identity.revision).to eq('98765')
+    end
+
+    it 'returns the empty string in the Heroku environment when no .gitsha file' do
+      allow(ENV).to receive(:[]).with("DYNO").and_return("foo")
+      expect(Napa::Identity.revision).to eq('')
     end
   end
 


### PR DESCRIPTION
@bellycard/platform, here is an attempt to get our git version working on heroku 

https://github.com/bellycard/heroku-buildpack-gitsha

```
https://github.com/bellycard/heroku-buildpack-gitsha.git
https://github.com/heroku/heroku-buildpack-ruby.git
```

I looked into if we could just create a new environment variable (and not need a napa change) with [ENV_DIR](https://devcenter.heroku.com/articles/buildpack-api#bin-detect), but that only reads the existing ones. This makes sense, but I wasted a lot of time trying to add a new config instead of thinking about how bad it would be if buildpacks could change those as they pleased...

I also looked into seeing if we could prevent a build if the gitsha didn't match master HEAD (or something like that), but I don't think we will be able to grab this information during a build (??). Someone smarter than me will have to look into that.