### PR TITLE
refactor and fix ActiveRecord setup for Heroku

### DIFF
--- a/lib/napa/cli/templates/new/config/initializers/active_record.rb
+++ b/lib/napa/cli/templates/new/config/initializers/active_record.rb
@@ -1,5 +1,8 @@
 require 'erb'
-db = YAML.load(ERB.new(File.read('./config/database.yml')).result)[Napa.env]
-ActiveRecord::Base.establish_connection(db)
+
 ActiveRecord::Base.logger = Napa::Logger.logger if Napa.env.development?
 ActiveRecord::Base.include_root_in_json = false
+
+db_config = ENV['DATABASE_URL'] || YAML.load(ERB.new(File.read('./config/database.yml')).result)[Napa.env]
+db_connection = ActiveRecord::Base.establish_connection(db_config)
+ActiveRecord::Base.configurations["db"] = db_connection.spec.config


### PR DESCRIPTION
@bellycard/platform 

So that Napa apps with ActiveRecord versions < 4.1 can use Heroku out of the box

Also, sets the configuration of ActiveRecord like Rails would