### PR TITLE
upgrade roar to current version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 master
 ===
+* [Support Roar > 1.0](https://github.com/bellycard/napa/pull/242)
 * [Move to CircleCI](https://github.com/bellycard/napa/pull/241)
 * [Fix for Logging bug in :basic format](https://github.com/bellycard/napa/pull/222)
 

--- a/lib/napa/output_formatters/representer.rb
+++ b/lib/napa/output_formatters/representer.rb
@@ -1,11 +1,23 @@
 require 'roar/decorator'
-require 'roar/representer/json'
-require 'roar/representer/feature/coercion'
+require 'roar/version'
+
+if Roar::VERSION >= '1.0.0'
+  require 'roar/json'
+  require 'roar/coercion'
+else
+  require 'roar/representer/json'
+  require 'roar/representer/feature/coercion'
+end
 
 module Napa
   class Representer < Roar::Decorator
-    include Roar::Representer::JSON
-    include ::Representable::Coercion
+    include Coercion
+
+    if Roar::VERSION >= '1.0.0'
+      include Roar::JSON
+    else
+      include Roar::Representer::JSON
+    end
 
     property :object_type, getter: ->(*) { self.class.name.underscore }
   end

--- a/napa.gemspec
+++ b/napa.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'virtus', '~> 1.0.0'
   gem.add_dependency 'grape', '~> 0.10.0'
   gem.add_dependency 'grape-swagger'
-  gem.add_dependency 'roar', '~> 0.12.0'
+  gem.add_dependency 'roar', ['>= 0.12.0', '< 2.0']
   gem.add_dependency 'statsd-ruby', '~> 1.2.0'
   gem.add_dependency 'racksh', '~> 1.0.0'
   gem.add_dependency 'git', '~> 1.2.0'


### PR DESCRIPTION
We define a subclass of Roar::Decorator and include some modules which have had their namespace changed in [roar 1.0.0](https://github.com/apotonick/roar/blob/master/CHANGES.markdown#100). 

Roar has seen a lot of new developments recently with support for hypermedia attributes. These changes along with the general value of not restricting dependency versions when we don't need to should merit this pull request.

In this pull request:
- unpin roar (remove the pessimistic version control)
- leave the minimum version at 0.12.0 as we need this for our decorator feature
- support both pre/post 1.0.0 (currently using a LoadError rescue)