### PR TITLE
Add a spec for logging format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp
 .ruby-version
 .ruby-gemset
 .DS_Store
+log

--- a/lib/napa/param_sanitizer.rb
+++ b/lib/napa/param_sanitizer.rb
@@ -1,4 +1,5 @@
 require 'action_dispatch/http/filter_parameters'
+require 'action_dispatch/http/parameter_filter'
 
 module Napa
   module ParamSanitizer

--- a/spec/logger/log_format_spec.rb
+++ b/spec/logger/log_format_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe 'Logging output format' do
+  capture_log_messages
+
+  it "Generic INFO log format" do
+    log_message      = "my cool message"
+    expected_message = "INFO  #{Napa::Logger.logger.name} : #{log_message}"
+
+    Napa::Logger.logger.info(log_message)
+
+    expect(@log_output.readline.strip).to eql(expected_message)
+  end
+
+  it "logs rack request" do
+    remote_addr = "127.0.0.1"
+    query       = "message=hello"
+    path        = "/hello/outside"
+    params      = { 'message' => 'hello' }
+
+    env = {
+      "QUERY_STRING"   => query,
+      "REQUEST_METHOD" => "GET",
+      "REQUEST_PATH"   => path,
+      "REQUEST_URI"    => path,
+      "PATH_INFO"      => path,
+      "REMOTE_ADDR"    => remote_addr,
+      "rack.input"     => StringIO.new
+    }
+
+    mock_app = Proc.new {}
+    Napa::Middleware::Logger.new(mock_app).call(env)
+
+    logger_name = Napa::Logger.logger.name
+
+    # using the output we are testing is a hack
+    # but it let's us us the hash object for the other parts
+    log_output = @log_output.readline.strip
+
+    pid        = log_output.match(/:pid=>(\d*)/)[1]
+    host       = log_output.gsub('"','').match(/:host=>(\S*),/)[1]
+    revision   = log_output.gsub('"','').match(/:revision=>(\S*),/)[1]
+
+    log_output_hash = { request: {
+        method:    "GET",
+        path:      path,
+        query:     query,
+        host:      host,
+        pid:       pid.to_i,
+        revision:  revision,
+        params:    params,
+        remote_ip: remote_addr
+      }
+    }
+
+    expected_log_message = "INFO  #{logger_name} : <Hash> #{log_output_hash.to_s}"
+
+    expect(log_output).to eq(expected_log_message)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,9 @@ ENV['RACK_ENV'] = 'test'
 require 'napa/setup'
 require 'acts_as_fu'
 
+require 'logging'
+require 'rspec/logging_helper'
+
 require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start
 
@@ -27,10 +30,8 @@ ActiveRecord::Schema.verbose = false
 # from https://gist.github.com/adamstegman/926858
 RSpec.configure do |config|
   config.include Napa::RspecExtensions::ResponseHelpers
-  config.extend NapaSpecClassHelpers
   config.include ActsAsFu
 
-  config.before(:each) do
-    allow(Napa::Logger).to receive_message_chain('logger.info').with(:napa_deprecation_warning)
-  end
+  config.extend NapaSpecClassHelpers
+  config.extend RSpec::LoggingHelper
 end


### PR DESCRIPTION
In preparation to move away from the `logging` gem we need a spec to ensure the format of the current request logs does not change.

This PR just aims to add these specs.

Remaining:
- add missing require: https://github.com/bellycard/napa/pull/258
- look into how to test the log output with CircleCI (maybe [this](https://github.com/fakefs/fakefs))
- incorporate new changes: https://github.com/bellycard/napa/pull/260
