### PR TITLE
add missing require for param sanitizer

### DIFF
--- a/lib/napa/param_sanitizer.rb
+++ b/lib/napa/param_sanitizer.rb
@@ -1,4 +1,5 @@
 require 'action_dispatch/http/filter_parameters'
+require 'action_dispatch/http/parameter_filter'
 
 module Napa
   module ParamSanitizer


### PR DESCRIPTION
@bellycard/platform 

We need this require for hitting this code path outside of an application

[It was added](https://github.com/rails/rails/commit/8ae9b4623e16f28c7954edcd89fbab2bba99b334) in the main codebase but we don't have that in actionpack 3.2.0

I need this for https://github.com/bellycard/napa/pull/257 as this spec hits this code path and errors.
