### PR TITLE
logged hashes converted to key/value strings

### DIFF
--- a/lib/napa.rb
+++ b/lib/napa.rb
@@ -40,6 +40,7 @@ require 'napa/sortable_api'
 
 require 'napa/deprecations'
 require 'napa/deploy'
+require 'napa/custom_logger'
 
 # load rake tasks if Rake installed
 if defined?(Rake)
@@ -53,6 +54,7 @@ module Napa
     def initialize
       return if Napa.skip_initialization
       Napa::Deprecations.initialization_checks
+      CustomLogger.define_log_methods(Napa::Logger.logger)
     end
   end
 end

--- a/lib/napa/custom_logger.rb
+++ b/lib/napa/custom_logger.rb
@@ -1,0 +1,32 @@
+module CustomLogger
+  extend self
+
+  def define_log_methods( logger )
+    ::Logging::LEVELS.each do |name,num|
+      code =  "undef :#{name}  if method_defined? :#{name}\n"
+      code << "undef :#{name}? if method_defined? :#{name}?\n"
+
+      if logger.level > num
+        code << <<-CODE
+          def #{name}?( ) false end
+          def #{name}( data = nil ) false end
+        CODE
+      else
+        code << <<-CODE
+          def #{name}?( ) true end
+          def #{name}( data = nil )
+            data = yield if block_given?
+            if data.kind_of?(Hash)
+              data = data.map { |k, v| k.to_s + '=' + v.to_s }.join(' ')
+            end
+            log_event(::Logging::LogEvent.new(@name, #{num}, data, @caller_tracing))
+            true
+          end
+        CODE
+      end
+
+      logger._meta_eval(code, __FILE__, __LINE__)
+    end
+    logger
+  end
+end

--- a/lib/napa/custom_logger.rb
+++ b/lib/napa/custom_logger.rb
@@ -1,5 +1,5 @@
 module CustomLogger
-  def define_log_methods(logger)
+  def self.define_log_methods(logger)
     ::Logging::LEVELS.each do |name, num|
       code =  "undef :#{name}  if method_defined? :#{name}\n"
       code << "undef :#{name}? if method_defined? :#{name}?\n"
@@ -27,5 +27,4 @@ module CustomLogger
     end
     logger
   end
-  module_funtion :define_log_methods
 end

--- a/lib/napa/custom_logger.rb
+++ b/lib/napa/custom_logger.rb
@@ -1,8 +1,6 @@
 module CustomLogger
-  extend self
-
-  def define_log_methods( logger )
-    ::Logging::LEVELS.each do |name,num|
+  def define_log_methods(logger)
+    ::Logging::LEVELS.each do |name, num|
       code =  "undef :#{name}  if method_defined? :#{name}\n"
       code << "undef :#{name}? if method_defined? :#{name}?\n"
 
@@ -17,7 +15,7 @@ module CustomLogger
           def #{name}( data = nil )
             data = yield if block_given?
             if data.kind_of?(Hash)
-              data = data.map { |k, v| k.to_s + '=' + v.to_s }.join(' ')
+              data = Napa::Logger.basic_request_format(data)
             end
             log_event(::Logging::LogEvent.new(@name, #{num}, data, @caller_tracing))
             true
@@ -29,4 +27,5 @@ module CustomLogger
     end
     logger
   end
+  module_funtion :define_log_methods
 end


### PR DESCRIPTION
@bellycard/platform 

[Trello](https://trello.com/c/zw1OCZuq/201-make-napa-logger-stop-publishing-hashes-to-the-logs)

When a hash is passed to a log line (non-request), it's in an unparseable format: `<Hash> {:foo=>"bar"}`

This extra work resets the data as `foo=bar`. It's an overwrite of this [logging gem method](https://github.com/TwP/logging/blob/4be0baea0bdf91be30d7f4ae8122fea0e5a6b91b/lib/logging/logger.rb#L84).

I tested this in CampaignService locally and got the correct logs. 