### PR TITLE
monkey patch logger method

### DIFF
--- a/lib/napa.rb
+++ b/lib/napa.rb
@@ -15,6 +15,7 @@ require 'napa/logger/output/stdout'
 require 'napa/logger/output/file'
 require 'napa/logger/configuration'
 require 'napa/logger/logger'
+require 'napa/logger/logging/logger'
 require 'napa/logger/log_transaction'
 require 'napa/logger/parseable'
 require 'napa/identity'
@@ -40,7 +41,6 @@ require 'napa/sortable_api'
 
 require 'napa/deprecations'
 require 'napa/deploy'
-require 'napa/custom_logger'
 
 # load rake tasks if Rake installed
 if defined?(Rake)
@@ -54,7 +54,6 @@ module Napa
     def initialize
       return if Napa.skip_initialization
       Napa::Deprecations.initialization_checks
-      CustomLogger.define_log_methods(Napa::Logger.logger)
     end
   end
 end

--- a/lib/napa/logger/logging/logger.rb
+++ b/lib/napa/logger/logging/logger.rb
@@ -1,4 +1,4 @@
-module CustomLogger
+class ::Logging::Logger
   def self.define_log_methods(logger)
     ::Logging::LEVELS.each do |name, num|
       code =  "undef :#{name}  if method_defined? :#{name}\n"

--- a/lib/napa/logger/logging/logger.rb
+++ b/lib/napa/logger/logging/logger.rb
@@ -1,4 +1,4 @@
-class ::Logging::Logger
+class Logging::Logger
   def self.define_log_methods(logger)
     ::Logging::LEVELS.each do |name, num|
       code =  "undef :#{name}  if method_defined? :#{name}\n"

--- a/lib/napa/logger/logging/logger.rb
+++ b/lib/napa/logger/logging/logger.rb
@@ -1,30 +1,32 @@
-class Logging::Logger
-  def self.define_log_methods(logger)
-    ::Logging::LEVELS.each do |name, num|
-      code =  "undef :#{name}  if method_defined? :#{name}\n"
-      code << "undef :#{name}? if method_defined? :#{name}?\n"
+module Logging
+  class Logger
+    def self.define_log_methods(logger)
+      ::Logging::LEVELS.each do |name, num|
+        code =  "undef :#{name}  if method_defined? :#{name}\n"
+        code << "undef :#{name}? if method_defined? :#{name}?\n"
 
-      if logger.level > num
-        code << <<-CODE
-          def #{name}?( ) false end
-          def #{name}( data = nil ) false end
-        CODE
-      else
-        code << <<-CODE
-          def #{name}?( ) true end
-          def #{name}( data = nil )
-            data = yield if block_given?
-            if data.kind_of?(Hash)
-              data = Napa::Logger.basic_request_format(data)
+        if logger.level > num
+          code << <<-CODE
+            def #{name}?( ) false end
+            def #{name}( data = nil ) false end
+          CODE
+        else
+          code << <<-CODE
+            def #{name}?( ) true end
+            def #{name}( data = nil )
+              data = yield if block_given?
+              if data.kind_of?(Hash)
+                data = Napa::Logger.basic_request_format(data)
+              end
+              log_event(::Logging::LogEvent.new(@name, #{num}, data, @caller_tracing))
+              true
             end
-            log_event(::Logging::LogEvent.new(@name, #{num}, data, @caller_tracing))
-            true
-          end
-        CODE
-      end
+          CODE
+        end
 
-      logger._meta_eval(code, __FILE__, __LINE__)
+        logger._meta_eval(code, __FILE__, __LINE__)
+      end
+      logger
     end
-    logger
   end
 end


### PR DESCRIPTION
@bellycard/platform 

While the hash conversion worked in campaign service, it didn't work in user facts. Ashton thinks it was because another method eventually came along and overwrote the method. This monkey patch seems to work, as I tested it locally in user-facts (which previously didn't work)