### PR TITLE
Param sanitizer attr accessor fix

### DIFF
--- a/lib/napa/param_sanitizer.rb
+++ b/lib/napa/param_sanitizer.rb
@@ -4,7 +4,7 @@ module Napa
   module ParamSanitizer
     include ActionDispatch::Http::FilterParameters
 
-    mattr_accessor :filter_params
+    attr_accessor :filter_params
     PAIR_REGEXP = /([^&;=]+)=([^&;=]+)/
 
     def filter_params


### PR DESCRIPTION
The ParamSanitizer had a call to mattr_accessor instead of attr_accessor.  This was preventing the napa server from working properly.
